### PR TITLE
explicitly include pg_config path

### DIFF
--- a/doc/plr.sgml
+++ b/doc/plr.sgml
@@ -53,6 +53,14 @@
     make
     make install
    </programlisting>
+   
+   You may explicitly include the path of pg_config to <literal>PATH</literal>, such as
+   <programlisting>
+    cd plr
+    PATH=/usr/pgsql-9.4/bin/:$PATH; USE_PGXS=1 make
+    echo 'PATH=/usr/pgsql-9.4/bin/:$PATH; USE_PGXS=1 make install' | sudo sh
+   </programlisting>
+   
   </para>
 
   <para>


### PR DESCRIPTION
```
USE_PGXS=1 make
USE_PGXS=1 make install
```
in  http://www.joeconway.com/plr/doc/plr-install.html is not good enough.

have to set the right pg_config path
```
PATH=/usr/pgsql-9.4/bin/:$PATH; USE_PGXS=1 make
echo 'PATH=/usr/pgsql-9.4/bin/:$PATH; USE_PGXS=1 make install' | sudo sh
```

although, it is not hard to figure out.

If the manual can be more informative, it will be great.